### PR TITLE
Remove use of JS func includes()

### DIFF
--- a/src/CurlImporter.js
+++ b/src/CurlImporter.js
@@ -124,7 +124,7 @@ class CurlImporter {
       // consider the body as a plain string
       else if (!contentType || contentType !== 'application/x-www-form-urlencoded') {
         const bodyString = curlRequest.get('bodyString')
-        if (contentType && contentType.includes('json')) {
+        if (contentType && contentType.indexOf('json') >= 0) {
           try {
             pawRequest.jsonBody = JSON.parse(bodyString)
           }

--- a/src/CurlParser.js
+++ b/src/CurlParser.js
@@ -338,7 +338,7 @@ export default class CurlParser {
     if (!acceptEncoding) {
       acceptEncoding = ''
     }
-    if (!acceptEncoding.includes('gzip')) {
+    if (acceptEncoding.indexOf('gzip') < 0) {
       if (acceptEncoding.length > 0) {
         acceptEncoding += ';'
       }


### PR DESCRIPTION
This function `includes()` wasn't compatible with the runtime installed on OS X 10.10+

This fixes #10 reported by @ccg
